### PR TITLE
A collection of changes to the PR

### DIFF
--- a/geometry/optimization/affine_subspace.cc
+++ b/geometry/optimization/affine_subspace.cc
@@ -23,7 +23,7 @@ AffineSubspace::AffineSubspace()
 
 AffineSubspace::AffineSubspace(const Eigen::Ref<const MatrixXd>& basis,
                                const Eigen::Ref<const VectorXd>& translation)
-    : ConvexSet(basis.rows()), basis_(basis), translation_(translation) {
+    : ConvexSet(basis.rows(), true), basis_(basis), translation_(translation) {
   DRAKE_THROW_UNLESS(basis_.rows() == translation_.size());
   DRAKE_THROW_UNLESS(basis_.rows() >= basis_.cols());
   if (basis.rows() > 0 && basis.cols() > 0) {
@@ -32,11 +32,10 @@ AffineSubspace::AffineSubspace(const Eigen::Ref<const MatrixXd>& basis,
   } else {
     basis_decomp_ = std::nullopt;
   }
-  set_has_exact_volume(true);
 }
 
 AffineSubspace::AffineSubspace(const ConvexSet& set, double tol)
-    : ConvexSet(0) {
+    : ConvexSet(0, true) {
   // If the set is clearly a singleton, we can easily compute its affine hull.
   const auto singleton_maybe = set.MaybeGetPoint();
   if (singleton_maybe.has_value()) {

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -102,18 +102,18 @@ bool IsRedundant(const Eigen::Ref<const MatrixXd>& c, double d,
 
 }  // namespace
 
-HPolyhedron::HPolyhedron() : ConvexSet(0) {}
+HPolyhedron::HPolyhedron() : ConvexSet(0, false) {}
 
 HPolyhedron::HPolyhedron(const Eigen::Ref<const MatrixXd>& A,
                          const Eigen::Ref<const VectorXd>& b)
-    : ConvexSet(A.cols()), A_(A), b_(b) {
+    : ConvexSet(A.cols(), false), A_(A), b_(b) {
   CheckInvariants();
 }
 
 HPolyhedron::HPolyhedron(const QueryObject<double>& query_object,
                          GeometryId geometry_id,
                          std::optional<FrameId> reference_frame)
-    : ConvexSet(3) {
+    : ConvexSet(3, false) {
   std::pair<MatrixXd, VectorXd> Ab_G;
   query_object.inspector().GetShape(geometry_id).Reify(this, &Ab_G);
 
@@ -128,7 +128,7 @@ HPolyhedron::HPolyhedron(const QueryObject<double>& query_object,
 }
 
 HPolyhedron::HPolyhedron(const VPolytope& vpoly)
-    : ConvexSet(vpoly.ambient_dimension()) {
+    : ConvexSet(vpoly.ambient_dimension(), false) {
   // First, handle the case where the VPolytope is empty.
   if (vpoly.IsEmpty()) {
     if (vpoly.ambient_dimension() == 0) {

--- a/geometry/optimization/hyperellipsoid.cc
+++ b/geometry/optimization/hyperellipsoid.cc
@@ -36,15 +36,14 @@ Hyperellipsoid::Hyperellipsoid()
 
 Hyperellipsoid::Hyperellipsoid(const Eigen::Ref<const MatrixXd>& A,
                                const Eigen::Ref<const VectorXd>& center)
-    : ConvexSet(center.size()), A_(A), center_(center) {
+    : ConvexSet(center.size(), true), A_(A), center_(center) {
   CheckInvariants();
-  set_has_exact_volume(true);
 }
 
 Hyperellipsoid::Hyperellipsoid(const QueryObject<double>& query_object,
                                GeometryId geometry_id,
                                std::optional<FrameId> reference_frame)
-    : ConvexSet(3) {
+    : ConvexSet(3, true) {
   Eigen::Matrix3d A_G;
   query_object.inspector().GetShape(geometry_id).Reify(this, &A_G);
   // p_GG_varᵀ * A_Gᵀ * A_G * p_GG_var ≤ 1

--- a/geometry/optimization/hyperrectangle.cc
+++ b/geometry/optimization/hyperrectangle.cc
@@ -31,22 +31,16 @@ using solvers::VectorXDecisionVariable;
 using symbolic::Expression;
 using symbolic::Variable;
 
-Hyperrectangle::Hyperrectangle() : ConvexSet(0) {}
+Hyperrectangle::Hyperrectangle() : ConvexSet(0, true) {}
 
 Hyperrectangle::Hyperrectangle(const Eigen::Ref<const Eigen::VectorXd>& lb,
                                const Eigen::Ref<const Eigen::VectorXd>& ub)
-    : ConvexSet(lb.size()), lb_(lb), ub_(ub) {
+    : ConvexSet(lb.size(), true), lb_(lb), ub_(ub) {
   CheckInvariants();
-  set_has_exact_volume(true);
 }
 
 std::unique_ptr<ConvexSet> Hyperrectangle::DoClone() const {
   return std::make_unique<Hyperrectangle>(*this);
-}
-
-bool Hyperrectangle::DoIsBounded() const {
-  // the finiteness of lb_ and ub_ is checked in the ctor.
-  return true;
 }
 
 std::optional<Eigen::VectorXd> Hyperrectangle::DoMaybeGetPoint() const {
@@ -166,6 +160,9 @@ Hyperrectangle::DoToShapeWithPose() const {
 }
 
 double Hyperrectangle::DoCalcVolume() const {
+  if (ambient_dimension() == 0) {
+    return 0.0;
+  }
   return (ub_ - lb_).prod();
 }
 

--- a/geometry/optimization/hyperrectangle.h
+++ b/geometry/optimization/hyperrectangle.h
@@ -56,8 +56,6 @@ class Hyperrectangle final : public ConvexSet {
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  bool DoIsBounded() const;
-
   /** An Hyperrectangle can not empty as lb <= ub is already checked in the ctor
    */
   bool DoIsEmpty() const final { return false; }

--- a/geometry/optimization/intersection.cc
+++ b/geometry/optimization/intersection.cc
@@ -35,10 +35,10 @@ int GetAmbientDimension(const ConvexSets& sets) {
 Intersection::Intersection() : Intersection(ConvexSets{}) {}
 
 Intersection::Intersection(const ConvexSets& sets)
-    : ConvexSet(GetAmbientDimension(sets)), sets_(sets) {}
+    : ConvexSet(GetAmbientDimension(sets), false), sets_(sets) {}
 
 Intersection::Intersection(const ConvexSet& setA, const ConvexSet& setB)
-    : ConvexSet(setA.ambient_dimension()) {
+    : ConvexSet(setA.ambient_dimension(), false) {
   DRAKE_THROW_UNLESS(setB.ambient_dimension() == setA.ambient_dimension());
   sets_.emplace_back(setA.Clone());
   sets_.emplace_back(setB.Clone());

--- a/geometry/optimization/minkowski_sum.cc
+++ b/geometry/optimization/minkowski_sum.cc
@@ -45,10 +45,10 @@ int GetAmbientDimension(const ConvexSets& sets) {
 MinkowskiSum::MinkowskiSum() : MinkowskiSum(ConvexSets{}) {}
 
 MinkowskiSum::MinkowskiSum(const ConvexSets& sets)
-    : ConvexSet(GetAmbientDimension(sets)), sets_(sets) {}
+    : ConvexSet(GetAmbientDimension(sets), false), sets_(sets) {}
 
 MinkowskiSum::MinkowskiSum(const ConvexSet& setA, const ConvexSet& setB)
-    : ConvexSet(setA.ambient_dimension()) {
+    : ConvexSet(setA.ambient_dimension(), false) {
   DRAKE_THROW_UNLESS(setB.ambient_dimension() == setA.ambient_dimension());
   sets_.emplace_back(setA.Clone());
   sets_.emplace_back(setB.Clone());
@@ -57,7 +57,7 @@ MinkowskiSum::MinkowskiSum(const ConvexSet& setA, const ConvexSet& setB)
 MinkowskiSum::MinkowskiSum(const QueryObject<double>& query_object,
                            GeometryId geometry_id,
                            std::optional<FrameId> reference_frame)
-    : ConvexSet(3) {
+    : ConvexSet(3, false) {
   Capsule capsule(1., 1.);
   query_object.inspector().GetShape(geometry_id).Reify(this, &capsule);
 

--- a/geometry/optimization/point.cc
+++ b/geometry/optimization/point.cc
@@ -22,14 +22,13 @@ using symbolic::Variable;
 
 Point::Point() : Point(VectorXd(0)) {}
 
-Point::Point(const Eigen::Ref<const VectorXd>& x) : ConvexSet(x.size()), x_(x) {
-  set_has_exact_volume(true);
-}
+Point::Point(const Eigen::Ref<const VectorXd>& x)
+    : ConvexSet(x.size(), true), x_(x) {}
 
 Point::Point(const QueryObject<double>& query_object, GeometryId geometry_id,
              std::optional<FrameId> reference_frame,
              double maximum_allowable_radius)
-    : ConvexSet(3) {
+    : ConvexSet(3, true) {
   double radius = -1.0;
   query_object.inspector().GetShape(geometry_id).Reify(this, &radius);
   if (radius > maximum_allowable_radius) {
@@ -45,7 +44,6 @@ Point::Point(const QueryObject<double>& query_object, GeometryId geometry_id,
   const RigidTransformd& X_WG = query_object.GetPoseInWorld(geometry_id);
   const RigidTransformd X_EG = X_WE.InvertAndCompose(X_WG);
   x_ = X_EG.translation();
-  set_has_exact_volume(true);
 }
 
 Point::~Point() = default;

--- a/geometry/optimization/spectrahedron.cc
+++ b/geometry/optimization/spectrahedron.cc
@@ -41,10 +41,10 @@ VectorXDecisionVariable GetVariablesByIndex(
 
 }  // namespace
 
-Spectrahedron::Spectrahedron() : ConvexSet(0) {}
+Spectrahedron::Spectrahedron() : ConvexSet(0, false) {}
 
 Spectrahedron::Spectrahedron(const MathematicalProgram& prog)
-    : ConvexSet(prog.num_vars()) {
+    : ConvexSet(prog.num_vars(), false) {
   for (const ProgramAttribute& attr : prog.required_capabilities()) {
     if (supported_attributes().count(attr) < 1) {
       throw std::runtime_error(fmt::format(

--- a/geometry/optimization/test/convex_set_test.cc
+++ b/geometry/optimization/test/convex_set_test.cc
@@ -109,48 +109,152 @@ GTEST_TEST(MakeConvexSetsTest, NoExtraCopying) {
   }
 }
 
-// Test the computation of the minimal axis-aligned bounding box of a
-// polyhedron. Then test the computation of the volume of the bounding box.
-GTEST_TEST(VolumeTest, BoundingBoxAroundHPolyhedron) {
+// Minimum implementation of a ConvexSet.
+class DummyVolumeSet : public ConvexSet {
+ public:
+  explicit DummyVolumeSet(bool can_calc_volume)
+      : ConvexSet(0, can_calc_volume) {}
+
+ protected:
+  std::unique_ptr<ConvexSet> DoClone() const override { return nullptr; }
+  bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>&,
+                    double) const override {
+    return false;
+  }
+  std::pair<VectorX<symbolic::Variable>,
+            std::vector<solvers::Binding<solvers::Constraint>>>
+  DoAddPointInSetConstraints(
+      solvers::MathematicalProgram*,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>&)
+      const override {
+    return {{}, {}};
+  }
+  std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram*,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>&,
+      const symbolic::Variable&) const override {
+    return {};
+  }
+  std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram*, const Eigen::Ref<const Eigen::MatrixXd>&,
+      const Eigen::Ref<const Eigen::VectorXd>&,
+      const Eigen::Ref<const Eigen::VectorXd>&, double,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>&,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>&)
+      const override {
+    return {};
+  }
+  std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
+      const override {
+    return {nullptr, {}};
+  }
+};
+
+// A convex set that doesn't implement DoCalcVolume but can erroneously report
+// that it can compute an exact volume.
+class NoImplSet final : public DummyVolumeSet {
+ public:
+  explicit NoImplSet(bool can_calc_volume) : DummyVolumeSet(can_calc_volume) {}
+};
+
+// A convex set that has implemented DoCalcVolume(), but can arbitrarily
+// indicate whether it has an exact volume. The value returned by DoCalcVolume()
+// depends on whether the constructor's `can_calc_volume` is true or false.
+// If true, `DoCalcVolume()` returns a positive value, if `false`, a negative
+// value. We should never get a negative value because CalcVolume() should throw
+// base on `has_exact_value()`.
+class HasImplSet final : public DummyVolumeSet {
+ public:
+  explicit HasImplSet(bool can_calc_volume)
+      : DummyVolumeSet(can_calc_volume), can_calc_volume_(can_calc_volume) {}
+
+ private:
+  double DoCalcVolume() const final { return can_calc_volume_ ? 1.5 : -1; }
+  bool can_calc_volume_{};
+};
+
+// Confirms that CalcVolume() respects has_exact_volume() and that errors in
+// derived classes are detected and reported.
+GTEST_TEST(ConvexSetTest, CalcVolume) {
+  // CalcVolume() correctly avoids calling DoCalcVolume().
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      NoImplSet(false).CalcVolume(),
+      ".*NoImplSet reports that it cannot report an exact volume.*");
+
+  // CalcVolume() calls DoCalcVolume(), revealing the class has lied.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      NoImplSet(true).CalcVolume(),
+      ".*NoImplSet has a defect -- has_exact_volume.. is reporting true.*");
+
+  // CalcVolume() correctly avoids calling the implemented DoCalcVolume().
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      HasImplSet(false).CalcVolume(),
+      ".*HasImplSet reports that it cannot report an exact volume.*");
+
+  // CalcVolume() called DoCalcVolume() correctly, and it returned a positive
+  // value.
+  EXPECT_GT(HasImplSet(true).CalcVolume(), 0);
+}
+
+// Tests the computation of the minimal axis-aligned bounding box of a
+// polyhedron.
+GTEST_TEST(ConvexSetTest, AxisAlignedBoundingBox) {
+  // Case: Unbounded.
+  {
+    Matrix<double, 4, 2> A;
+    Matrix<double, 4, 1> b;
+    // clang-format off
+    A <<  1,  1,  // x + y ≤ 1
+         -1,  0,  // x ≥ -2
+         -1, -1;  // x+y ≥ -1
+    b << 1, 2, 1;
+    // clang-format on
+    HPolyhedron H(A, b);
+    EXPECT_FALSE(H.MaybeCalcAxisAlignedBoundingBox().has_value());
+  }
+
+  // Case: Bounded parallelogram.
+  {
+    Matrix<double, 4, 2> A;
+    Matrix<double, 4, 1> b;
+    // clang-format off
+    A <<  1,  0,  // x ≤ 1
+          1,  1,  // x + y ≤ 1
+         -1,  0,  // x ≥ -2
+         -1, -1;  // x+y ≥ -1
+    b << 1, 1, 2, 1;
+    // clang-format on
+    HPolyhedron H(A, b);
+    std::optional<Hyperrectangle> aabb_opt =
+        H.MaybeCalcAxisAlignedBoundingBox();
+    EXPECT_TRUE(aabb_opt.has_value());
+    const auto& aabb = aabb_opt.value();
+    EXPECT_NEAR(aabb.lb()(0), -2, 1e-6);
+    EXPECT_NEAR(aabb.ub()(0), 1, 1e-6);
+    EXPECT_NEAR(aabb.lb()(1), -2, 1e-6);
+    EXPECT_NEAR(aabb.ub()(1), 3, 1e-6);
+  }
+}
+
+GTEST_TEST(ConvexSetTest, CalcVolumeViaSampling) {
   Matrix<double, 4, 2> A;
   Matrix<double, 4, 1> b;
   // clang-format off
   A <<  1,  0,  // x ≤ 1
         1,  1,  // x + y ≤ 1
        -1,  0,  // x ≥ -2
-        -1, -1;  // x+y ≥ -1
+       -1, -1;  // x+y ≥ -1
   b << 1, 1, 2, 1;
   // clang-format on
   HPolyhedron H(A, b);
-  std::optional<Hyperrectangle> aabb_opt = H.MaybeCalcAxisAlignedBoundingBox();
-  EXPECT_TRUE(aabb_opt.has_value());
-  const auto& aabb = aabb_opt.value();
-  EXPECT_NEAR(aabb.lb()(0), -2, 1e-6);
-  EXPECT_NEAR(aabb.ub()(0), 1, 1e-6);
-  EXPECT_NEAR(aabb.lb()(1), -2, 1e-6);
-  EXPECT_NEAR(aabb.ub()(1), 3, 1e-6);
-  // An HPolyhedron does not have an exact volume.
-  EXPECT_FALSE(H.has_exact_volume());
-  // exact volume of a hyperrectangle can be computed
-  EXPECT_TRUE(aabb.has_exact_volume());
-  // If the hyperractangle is cast as a ConvexSet, it does still have an exact
-  // volume.
-  const ConvexSet& aabb_convex_set = aabb;
-  EXPECT_TRUE(aabb_convex_set.has_exact_volume());
-  // But it does not throw an exception when computing the volume.
-  EXPECT_NO_THROW(aabb_convex_set.CalcVolume());
-  // Check the volume of the bounding box.
-  EXPECT_NEAR(aabb.CalcVolume(), 15, 1e-6);
-  // The H-polyhedron volume throws an exception that asks user to use
-  // CalcVolumeViaSampling instead.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      H.CalcVolume(), ".*HPolyhedron.*Use CalcVolumeViaSampling.. instead.");
-  // Compute the volume of the polytope
+
+  // Compute the estimated volume of the polytope.
   RandomGenerator generator(1234);
-  const auto polytope_volume = H.CalcVolumeViaSampling(&generator, 1e-2);
-  // Hpolyhedron volume is compared against the analytic value = 6.0 as it is a
-  // parallelogram.
-  EXPECT_NEAR(polytope_volume, 6.0, 1e-1);
+  const auto estimated_volume = H.CalcVolumeViaSampling(&generator, 1e-2);
+  // H is a simple parallelogram with volume 6.0.
+  EXPECT_NEAR(estimated_volume, 6.0, 1e-1);
 };
 
 }  // namespace

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -1141,6 +1141,15 @@ GTEST_TEST(HPolyhedronTest, UniformSampleTest2) {
   EXPECT_GT(num_success, 0);
 }
 
+GTEST_TEST(HPolyhedronTest, Serialize) {
+  const HPolyhedron H = HPolyhedron::MakeL1Ball(3);
+  const std::string yaml = yaml::SaveYamlString(H);
+  const auto H2 = yaml::LoadYamlString<HPolyhedron>(yaml);
+  EXPECT_EQ(H.ambient_dimension(), H2.ambient_dimension());
+  EXPECT_TRUE(CompareMatrices(H.A(), H2.A()));
+  EXPECT_TRUE(CompareMatrices(H.b(), H2.b()));
+}
+
 }  // namespace optimization
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/optimization/test/hyperrectangle_test.cc
+++ b/geometry/optimization/test/hyperrectangle_test.cc
@@ -35,8 +35,22 @@ bool PointInScaledSet(const solvers::VectorXDecisionVariable& x_vars,
   return prog->CheckSatisfiedAtInitialGuess(constraints, tol);
 }
 
+GTEST_TEST(HyperrectangleTest, Default) {
+  const Hyperrectangle dut;
+  EXPECT_EQ(dut.ambient_dimension(), 0);
+  EXPECT_DOUBLE_EQ(dut.CalcVolume(), 0);
+  EXPECT_EQ(dut.Center().size(), 0);
+  EXPECT_TRUE(dut.MaybeGetPoint().has_value());
+  EXPECT_EQ(dut.MaybeGetPoint()->size(), 0);
+  EXPECT_TRUE(dut.MaybeGetFeasiblePoint().has_value());
+  EXPECT_EQ(dut.MaybeGetFeasiblePoint()->size(), 0);
+  EXPECT_TRUE(dut.PointInSet(VectorXd()));
+  const auto hpolyhedron = dut.MakeHPolyhedron();
+  EXPECT_EQ(hpolyhedron.ambient_dimension(), 0);
+}
+
 // Test functions on hyperrectangle.
-GTEST_TEST(HyperRectangleTest, BasicTests) {
+GTEST_TEST(HyperrectangleTest, BasicTests) {
   const Vector3d lb{-1, -2, -3};
   const Vector3d ub{3, 2, 1};
   const Hyperrectangle hyperrectangle(lb, ub);
@@ -71,7 +85,7 @@ GTEST_TEST(HyperRectangleTest, BasicTests) {
       point_hyperrectangle.MaybeGetFeasiblePoint().value(), Vector3d{1, 2, 3}));
 }
 
-GTEST_TEST(HyperRectangleTest, Sampling) {
+GTEST_TEST(HyperrectangleTest, Sampling) {
   const Hyperrectangle hyperrectangle(Eigen::Vector2d{-1, -2},
                                       Eigen::Vector2d{3, 2});
   const int n_samples = 1000;
@@ -94,13 +108,13 @@ GTEST_TEST(HyperRectangleTest, Sampling) {
       CompareMatrices(variance, Eigen::Vector2d{16.0 / 12, 16.0 / 12}, 1e-1));
 }
 
-GTEST_TEST(HyperRectangleTest, InfinityTest) {
+GTEST_TEST(HyperrectangleTest, InfinityTest) {
   const auto lb = Vector3d::Constant(-std::numeric_limits<double>::infinity());
   const auto ub = Vector3d::Constant(1);
   EXPECT_THROW(Hyperrectangle(lb, ub), std::exception);
 }
 
-GTEST_TEST(HyperRectangleTest, AddPointInConstraints) {
+GTEST_TEST(HyperrectangleTest, AddPointInSetConstraints) {
   const Vector3d lb{-1, -2, -3};
   const Vector3d ub{3, 2, 1};
   const Hyperrectangle hyperrectangle(lb, ub);
@@ -121,8 +135,8 @@ GTEST_TEST(HyperRectangleTest, AddPointInConstraints) {
   EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(con[0]));
 }
 
-// Test AddPointInNonnegativeScalingConstraints
-GTEST_TEST(HyperRectangleTest, AddPointInNonnegativeScalingConstraints) {
+// Test AddPointInNonnegativeScalingConstraints.
+GTEST_TEST(HyperrectangleTest, AddPointInNonnegativeScalingConstraints) {
   // Test AddPointInNonnegativeScalingConstraints
   const Vector3d lb{-1, -2, -3};
   const Vector3d ub{3, 2, 1};
@@ -148,8 +162,8 @@ GTEST_TEST(HyperRectangleTest, AddPointInNonnegativeScalingConstraints) {
   EXPECT_FALSE(prog.CheckSatisfiedAtInitialGuess(scaled_con));
 }
 
-// Test AddPointInNonnegativeScalingConstraints with matrices
-GTEST_TEST(HyperRectangleTest,
+// Test AddPointInNonnegativeScalingConstraints with matrices.
+GTEST_TEST(HyperrectangleTest,
            AddPointInNonnegativeScalingConstraintsWithMatrices) {
   const Vector3d lb{-1, -2, -3};
   const Vector3d ub{3, 2, 1};
@@ -204,7 +218,7 @@ GTEST_TEST(HyperRectangleTest,
   }
 }
 
-GTEST_TEST(HyperRectangleTest, Serialize) {
+GTEST_TEST(HyperrectangleTest, Serialize) {
   const Vector3d lb{-1, -2, -3};
   const Vector3d ub{3, 2, 1};
   const Hyperrectangle hyperrectangle(lb, ub);

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -121,14 +121,12 @@ MatrixXd GetConvexHullFromObjFile(const std::string& filename,
 VPolytope::VPolytope() : VPolytope(MatrixXd(0, 0)) {}
 
 VPolytope::VPolytope(const Eigen::Ref<const MatrixXd>& vertices)
-    : ConvexSet(vertices.rows()), vertices_(vertices) {
-  set_has_exact_volume(true);
-}
+    : ConvexSet(vertices.rows(), true), vertices_(vertices) {}
 
 VPolytope::VPolytope(const QueryObject<double>& query_object,
                      GeometryId geometry_id,
                      std::optional<FrameId> reference_frame)
-    : ConvexSet(3) {
+    : ConvexSet(3, true) {
   Matrix3Xd vertices;
   query_object.inspector().GetShape(geometry_id).Reify(this, &vertices);
 
@@ -138,11 +136,10 @@ VPolytope::VPolytope(const QueryObject<double>& query_object,
   const RigidTransformd& X_WG = query_object.GetPoseInWorld(geometry_id);
   const RigidTransformd X_EG = X_WE.InvertAndCompose(X_WG);
   vertices_ = X_EG * vertices;
-  set_has_exact_volume(true);
 }
 
 VPolytope::VPolytope(const HPolyhedron& hpoly)
-    : ConvexSet(hpoly.ambient_dimension()) {
+    : ConvexSet(hpoly.ambient_dimension(), true) {
   DRAKE_THROW_UNLESS(hpoly.IsBounded());
 
   MatrixXd coeffs(hpoly.A().rows(), hpoly.A().cols() + 1);
@@ -201,7 +198,6 @@ VPolytope::VPolytope(const HPolyhedron& hpoly)
                         eigen_center;
     ii++;
   }
-  set_has_exact_volume(true);
 }
 
 VPolytope::~VPolytope() = default;


### PR DESCRIPTION
1. Make the `has_exact_volume` part of constructor.
2. Change (and test) ConvexSet::CalcVolume() semsnatics.
   - related change to the default implementation of DoCalcVolume().
3. Small tweaks (typos, punctuation, etc.)
4. Cleaned up left over Hyperrectangle::DoIsBounded()
5. "Fixed" Hyperrectangle volume for default rectangle.
6. Refactoring of ConvexSet tests for computing bounding rectangle and volume via sampling.
7. Restore HPolyhedronTest, Serialize

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sadraddini/drake/1)
<!-- Reviewable:end -->